### PR TITLE
revert debian basefiles to 13.2

### DIFF
--- a/debian_archives.bzl
+++ b/debian_archives.bzl
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def repositories():
     http_file(
         name = "riscv64_unstable_base-files",
-        downloaded_file_path = "base-files_13.3_riscv64.deb",
-        sha256 = "927390ff9a03c36119f5d736abf46a692769771373d7426032cebe9667776733",
-        urls = ["https://snapshot.debian.org/archive/debian/20240701T023644Z/pool/main/b/base-files/base-files_13.3_riscv64.deb"],
+        downloaded_file_path = "base-files_13.2_riscv64.deb",
+        sha256 = "8c5100c6bf24743c7863def820fd36d1ac692e4863672cef57dd6a1607376fff",
+        urls = ["https://snapshot.debian.org/archive/debian/20240512T204749Z/pool/main/b/base-files/base-files_13.2_riscv64.deb"],
     )
     http_file(
         name = "riscv64_unstable_ca-certificates",

--- a/debian_versions.bzl
+++ b/debian_versions.bzl
@@ -2,7 +2,7 @@
 DEBIAN_PACKAGE_VERSIONS = {
     "riscv64": {
         "unstable": {
-            "base-files": "13.3",
+            "base-files": "13.2",
             "ca-certificates": "20240203",
             "libc-bin": "2.38-13",
             "libc6": "2.38-13",


### PR DESCRIPTION
#68 introduces a bump of the basefiles to `13.3`. The changelog for this version has a single entry:
```
base-files (13.3) unstable; urgency=medium

  [ Helmut Grohne ]
  * DEP17: Install /usr-merge aliasing symlinks. Closes: #1064459.

 -- Santiago Vila <sanvila@debian.org>  Thu, 06 Jun 2024 00:35:00 +0200
```

The link to the aforementioned issue with more details: https://bugs-devel.debian.org/cgi-bin/bugreport.cgi?bug=1064459

In short it introduces symlinks in the root folder. Here is how the root looks in `13.2`:
```shell
bin/
boot/
dev/
etc/
home/
lib/
proc/
root/
run/
sbin/
sys/
tmp/
usr/
var/
```

And this is `13.3`:

```shell
bin@
boot/
dev/
etc/
home/
lib@
proc/
root/
run/
sbin@
sys/
tmp/
usr/
var/
```

As seen, some toplevel folders are symbolic links. Now this is not a problem for the regular debian root, but it is a problem for a base container image. Since the Dockerfile COPY directive does not work well with folder symlinks.

Therefore here we revert it back to `13.2`, and we probably need to pin it like this.